### PR TITLE
Draftodon 1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 drafts.d.ts
 testing_dump.js
+drafts-definitions.js

--- a/Action Descriptions.md
+++ b/Action Descriptions.md
@@ -74,7 +74,7 @@ This Action is helpful if you compose a longer post and you are not sure if it w
 
 This Action will do excatly what its name implies. it will post the contents of the draft to mastodon. Therefore it will use the configured mastodon instance in "Draftodon Settings".
 
-The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. If you want to use the Action with different visibilities, just duplicate it, then change the template tag e.g. to `private` and rename the Action for easier identification.
+The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. You can find information about supported visibilities by opening the Draftodon Instructions.
 
 If you run this the first time, you will need to authenticate Drafts for your account (only need to do this once).
 
@@ -85,7 +85,7 @@ If you run this the first time, you will need to authenticate Drafts for your ac
 This Action will schedule the current draft as prompt to mastodon. It will present a prompt where you can set the date and time when it should be published, when you select a date the draft will be sent to mastodon and schedule it for publishing.
 If you want to chack your scheduled posts you can use the "show scheduled posts" Action.
 
-The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. If you want to use the Action with different visibilities, just duplicate it, then change the template tag e.g. to `private` and rename the Action for easier identification.
+The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. You can find information about supported visibilities by opening the Draftodon Instructions.
 
 If you run this the first time, you will need to authenticate Drafts for your account (only need to do this once).
 
@@ -106,7 +106,7 @@ option 3
 
 The Action will present a prompt to show you the created poll and you can make adjustments to the default settings like changing the expire date, allowing multiple answers or hiding the totals in the poll.
 
-The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. If you want to use the Action with different visibilities, just duplicate it, then change the template tag e.g. to `private` and rename the Action for easier identification.
+The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. You can find information about supported visibilities by opening the Draftodon Instructions.
 
 If you run this the first time, you will need to authenticate Drafts for your account (only need to do this once).
 
@@ -127,7 +127,7 @@ option 3
 
 The Action will present a prompt to show you the created poll and you can make adjustments to the default settings like changing the expire date, allowing multiple answers or hiding the totals in the poll.
 
-The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. If you want to use the Action with different visibilities, just duplicate it, then change the template tag e.g. to `private` and rename the Action for easier identification.
+The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. You can find information about supported visibilities by opening the Draftodon Instructions.
 
 If you run this the first time, you will need to authenticate Drafts for your account (only need to do this once).
 
@@ -146,7 +146,7 @@ which will be hidden behind the content warning
 
 If the draft only consist of one line, the Action will consider the text as the text that shall be hidden and will ask for the spoiler text in a prompt.
 
-The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. If you want to use the Action with different visibilities, just duplicate it, then change the template tag e.g. to `private` and rename the Action for easier identification.
+The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. You can find information about supported visibilities by opening the Draftodon Instructions.
 
 If you run this the first time, you will need to authenticate Drafts for your account (only need to do this once).
 
@@ -165,7 +165,7 @@ which will be hidden behind the content warning
 
 If the draft only consist of one line, the Action will consider the text as the text that shall be hidden and will ask for the spoiler text in a prompt.
 
-The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. If you want to use the Action with different visibilities, just duplicate it, then change the template tag e.g. to `private` and rename the Action for easier identification.
+The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. You can find information about supported visibilities by opening the Draftodon Instructions.
 
 If you run this the first time, you will need to authenticate Drafts for your account (only need to do this once).
 
@@ -175,7 +175,17 @@ If you run this the first time, you will need to authenticate Drafts for your ac
 
 This Action lets you reply to a status. To reply to a status just copy the link of it and paste it into the first line of a Draft. Then type your reply below the url. The Action will validate that it is a correct status url and post the reply.
 
-The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. If you want to use the Action with different visibilities, just duplicate it, then change the template tag e.g. to `private` and rename the Action for easier identification.
+The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. You can find information about supported visibilities by opening the Draftodon Instructions.
+
+If you run this the first time, you will need to authenticate Drafts for your account (only need to do this once).
+
+> After Success Setting: *Archive*
+
+## quote status
+
+This Action lets you quote a status. Since Mastodon does not (yet) support quoting posts this is a small workaround. To quote a status copy the link of it and paste it into the first line of a new Draft. Then type your quoting text (your comment on that post or whatever) below the url. The Action will validate that it is a correct status url and append the following text to your quote before publishing it: `"💬 @[account] [url]`
+
+The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. You can find information about supported visibilities by opening the Draftodon Instructions.
 
 If you run this the first time, you will need to authenticate Drafts for your account (only need to do this once).
 
@@ -202,7 +212,7 @@ The Action will:
 - publish the Thread on Mastodon if it is valid AND you select "continue" in the html preview
 	- the first post of the thread will be a public post, every subsequent post will be an unlisted reply - therefore it won't clutter up the public timelines of your followers, if they open the first post, they will see all subsequent replies.
 
-The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. If you want to use the Action with different visibilities, just duplicate it, then change the template tag e.g. to `private` and rename the Action for easier identification.
+The Action contains the "Template Tag" `post-visibility`, which allows to specify the visibility of the published post and defaults to `public`. You can find information about supported visibilities by opening the Draftodon Instructions.
 
 If you run this the first time, you will need to authenticate Drafts for your account (only need to do this once).
 

--- a/Draftodon Instructions.md
+++ b/Draftodon Instructions.md
@@ -40,6 +40,17 @@ Draftodon posts directly to your Mastodon Profile if you run the Actions it will
 
 Every Draftodon Action contains a short description about its purpose / what it does. Due to the big amount of Actions you can also read through all descriptions in the [Action Descriptions](https://github.com/FlohGro-dev/Draftodon/blob/main/Action%20Descriptions.md) file.
 
+## Visibility of Posts
+
+Mastodon supports different visibilities for posts. The Actions in Draftodon that publish posts will be default use `public` but you can change that by editing the actions and changing the template tag "post-visibility" to one of the following valid settings:
+
+- public: Visible to everyone, shown in public timelines.
+- unlisted: Visible to public, but not included in public timelines.
+- private: Visible to followers only, and to any mentioned users.
+- direct: Visible only to mentioned users.
+
+You can find the official documentation of the visibilities in the [Mastodon API documentation](https://docs.joinmastodon.org/entities/Status/#visibility).
+
 ## Draftodon with multiple accounts
 
 To use Draftodon with multiple accounts you just need to configure every instance and handle that you might want to use.

--- a/Draftodon Instructions.md
+++ b/Draftodon Instructions.md
@@ -42,7 +42,7 @@ Every Draftodon Action contains a short description about its purpose / what it 
 
 ## Visibility of Posts
 
-Mastodon supports different visibilities for posts. The Actions in Draftodon that publish posts will be default use `public` but you can change that by editing the actions and changing the template tag "post-visibility" to one of the following valid settings:
+Mastodon supports different visibilities for posts. The Actions in Draftodon that publish posts will be default use `public` but you can change that by editing the actions and adapting the template tag "post-visibility" to one of the following valid settings:
 
 - public: Visible to everyone, shown in public timelines.
 - unlisted: Visible to public, but not included in public timelines.

--- a/Draftodon Instructions.md
+++ b/Draftodon Instructions.md
@@ -49,6 +49,8 @@ Mastodon supports different visibilities for posts. The Actions in Draftodon tha
 - private: Visible to followers only, and to any mentioned users.
 - direct: Visible only to mentioned users.
 
+If you want to use Actions with different options for the visibility I recommend to duplicate them and change the visibility setting. Don't forget to rename the Actions for easier identification.
+
 You can find the official documentation of the visibilities in the [Mastodon API documentation](https://docs.joinmastodon.org/entities/Status/#visibility).
 
 ## Draftodon with multiple accounts


### PR DESCRIPTION
inor:
- [x] "#" is now added even when no option is selected in "insert hashtag" prompt 
- [x] "@" is now added even when no option is selected in the "insert Mastodon handle" prompt

New:
- [x] public url appended to published drafts
- [x] Quote Post action (similar ro reply to action)